### PR TITLE
Add fast-uuid for UUID from String benchmarks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <version.jmh>1.27</version.jmh>
+        <version.jmh>1.32</version.jmh>
     </properties>
 
     <dependencies>
@@ -39,7 +39,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>27.0-jre</version>
+        <version>31.0.1-jre</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
         <artifactId>java-uuid-generator</artifactId>
         <version>4.0.1</version>
       </dependency>
+      <dependency>
+        <groupId>com.eatthepath</groupId>
+        <artifactId>fast-uuid</artifactId>
+        <version>0.2.0</version>
+      </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
```
Benchmark                                    Mode  Cnt        Score        Error  Units
ValidUUIDFromString.m1_UUID_with_JDK        thrpt   15    92348.321 ±    617.624  ops/s
ValidUUIDFromString.m2_UUID_with_JUG        thrpt   15   460677.879 ±  42375.220  ops/s
ValidUUIDFromString.m2_UUID_with_fast_uuid  thrpt   15  1083386.234 ±   4874.232  ops/s
ValidUUIDFromString.m3_UUID_with_manual     thrpt   15  1023579.664 ± 139337.154  ops/s
```

Seems to be slightly faster/more consistent than Jackson's, at least on OpenJDK 8.

They also have an interesting method for writing UUIDs into Strings.
